### PR TITLE
Add simple soccer manager page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # projetoarquimedes2
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/Edermengo/projetoarquimedes2)
+
+## Soccer Manager Demo
+
+Uma página simples de gerenciamento de time de futebol foi adicionada ao projeto. Ela permite contratar e demitir jogadores e simular partidas. Acesse `Soccer Manager` no menu após fazer login.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard';
 import BudgetEditor from './pages/BudgetEditor';
 import PriceDatabase from './pages/PriceDatabase';
 import Reports from './pages/Reports';
+import SoccerManager from './pages/SoccerManager';
 import Auth from './components/Auth';
 import { useAuthStore } from './store/auth';
 
@@ -83,6 +84,16 @@ function App() {
               <PrivateRoute>
                 <Layout>
                   <Reports />
+                </Layout>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/soccer-manager"
+            element={
+              <PrivateRoute>
+                <Layout>
+                  <SoccerManager />
                 </Layout>
               </PrivateRoute>
             }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Box, AppBar, Toolbar, Typography, Drawer, List, ListItem, ListItemIcon, ListItemText, Button } from '@mui/material';
-import { Dashboard, Description, AttachMoney, Assessment, Logout } from '@mui/icons-material';
+import { Dashboard, Description, AttachMoney, Assessment, Logout, SportsSoccer } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/auth';
 
@@ -18,6 +18,7 @@ export default function Layout({ children }: LayoutProps) {
     { text: 'Editor de Orçamento', icon: <Description />, path: '/budget-editor' },
     { text: 'Banco de Preços', icon: <AttachMoney />, path: '/price-database' },
     { text: 'Relatórios', icon: <Assessment />, path: '/reports' },
+    { text: 'Soccer Manager', icon: <SportsSoccer />, path: '/soccer-manager' },
   ];
 
   const handleSignOut = async () => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Typography, Grid, Paper, Button, List, ListItem, ListItemText, CircularProgress } from '@mui/material';
-import { Add, FolderOpen } from '@mui/icons-material';
+import { Add } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 

--- a/src/pages/PriceDatabase.tsx
+++ b/src/pages/PriceDatabase.tsx
@@ -88,7 +88,6 @@ export default function PriceDatabase() {
       reader.onload = async (e) => {
         const text = e.target?.result as string;
         const lines = text.split('\n');
-        const headers = lines[0].split(',');
 
         const items = lines.slice(1).map((line) => {
           const values = line.split(',');

--- a/src/pages/SoccerManager.tsx
+++ b/src/pages/SoccerManager.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+
+interface Player {
+  id: number;
+  name: string;
+  position: string;
+  skill: number;
+}
+
+function createRandomPlayer(id: number): Player {
+  const names = ['João', 'Pedro', 'Lucas', 'Mateus', 'Rafael'];
+  const positions = ['Goleiro', 'Zagueiro', 'Meia', 'Atacante'];
+  return {
+    id,
+    name: names[Math.floor(Math.random() * names.length)],
+    position: positions[Math.floor(Math.random() * positions.length)],
+    skill: Math.floor(Math.random() * 100) + 1,
+  };
+}
+
+export default function SoccerManager() {
+  const [players, setPlayers] = useState<Player[]>([
+    createRandomPlayer(1),
+    createRandomPlayer(2),
+    createRandomPlayer(3),
+  ]);
+  const [funds, setFunds] = useState(1000);
+  const [name, setName] = useState('');
+  const [position, setPosition] = useState('');
+
+  const addPlayer = () => {
+    if (!name || !position) return;
+    const newPlayer: Player = {
+      id: Date.now(),
+      name,
+      position,
+      skill: Math.floor(Math.random() * 100) + 1,
+    };
+    setPlayers([...players, newPlayer]);
+    setName('');
+    setPosition('');
+    setFunds(funds - 50); // custo de contratação
+  };
+
+  const removePlayer = (id: number) => {
+    setPlayers(players.filter((p) => p.id !== id));
+  };
+
+  const playMatch = () => {
+    const teamSkill = players.reduce((acc, p) => acc + p.skill, 0);
+    const opponentSkill = Math.floor(Math.random() * (players.length * 100));
+    if (teamSkill >= opponentSkill) {
+      setFunds(funds + 100);
+      alert('Você venceu a partida!');
+    } else {
+      setFunds(funds - 50);
+      alert('Você perdeu a partida.');
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Gerenciador de Time de Futebol
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        Caixa: {funds.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+      </Typography>
+
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <Typography variant="h6">Elenco</Typography>
+        <List>
+          {players.map((player) => (
+            <ListItem
+              key={player.id}
+              secondaryAction={
+                <Button color="error" onClick={() => removePlayer(player.id)}>
+                  Demitir
+                </Button>
+              }
+            >
+              <ListItemText
+                primary={`${player.name} - ${player.position}`}
+                secondary={`Habilidade: ${player.skill}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+
+        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+          <TextField
+            label="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <TextField
+            label="Posição"
+            value={position}
+            onChange={(e) => setPosition(e.target.value)}
+          />
+          <Button variant="contained" onClick={addPlayer}>
+            Contratar
+          </Button>
+        </Box>
+      </Paper>
+
+      <Button variant="contained" color="primary" onClick={playMatch}>
+        Jogar Partida
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Soccer Manager demo page
- expose Soccer Manager route and menu item
- clean up unused variables to fix build
- document the new page in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68437926ad708331a87f9fa6317627dd